### PR TITLE
CodeAid/Fixed 87059177-493e-4ae1-8561-cb03fc957ab5

### DIFF
--- a/java_server/src/main/java/com/mgmsec/HackMyTeeth/HackMyTeeth/controllers/LoginController.java
+++ b/java_server/src/main/java/com/mgmsec/HackMyTeeth/HackMyTeeth/controllers/LoginController.java
@@ -39,24 +39,24 @@ public class LoginController {
 	@Autowired
 	CapchaService capchaService;
 
-	@RequestMapping("/login")
-	public ModelAndView firstPage(Model model, HttpServletRequest request) {
-		ModelAndView modelAndView = new ModelAndView();
-		Cookie loginCookie = sessService.checkLoginCookie(request);
-		if (loginCookie != null) {
-			Session session = sessService.findBySession(loginCookie.getValue());
-			if (session != null) return new ModelAndView("redirect:/home");
-		}
-		switch (secSettings.getPwBruteForce()){
-			case Captcha:
-					model.addAttribute("isCaptchaEnabled",true);
-					break;
-				default:
-					break;
-		}
-		modelAndView.setViewName("login");
-		return modelAndView;
-	}
+	@RequestMapping(value = "/login", method = RequestMethod.GET)
+public ModelAndView firstPage(Model model, HttpServletRequest request) {
+    ModelAndView modelAndView = new ModelAndView();
+    Cookie loginCookie = sessService.checkLoginCookie(request);
+    if (loginCookie != null) {
+        Session session = sessService.findBySession(loginCookie.getValue());
+        if (session != null) return new ModelAndView("redirect:/home");
+    }
+    switch (secSettings.getPwBruteForce()){
+        case Captcha:
+                model.addAttribute("isCaptchaEnabled",true);
+                break;
+            default:
+                break;
+    }
+    modelAndView.setViewName("login");
+    return modelAndView;
+}
 	@RequestMapping("/")
 	public ModelAndView slash() {
 		return new ModelAndView("redirect:/login");

--- a/test/java_server/src/main/java/com/mgmsec/HackMyTeeth/HackMyTeeth/controllers/LoginControllerTest.java
+++ b/test/java_server/src/main/java/com/mgmsec/HackMyTeeth/HackMyTeeth/controllers/LoginControllerTest.java
@@ -1,0 +1,27 @@
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.ui.Model;
+import org.springframework.web.servlet.ModelAndView;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class LoginControllerTest {
+
+    @Test
+    public void testFirstPageRequestMethod() {
+        // Arrange
+        LoginController controller = new LoginController();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        Model model = mock(Model.class);
+
+        // Act
+        ModelAndView result = controller.firstPage(model, request);
+
+        // Assert
+        assertEquals("login", result.getViewName(), "The view name should be 'login'");
+    }
+}


### PR DESCRIPTION
## What did you do? 
 - Fixed the security issue by CodeAid
## Why did you do it? 
 - Detected a method annotated with 'RequestMapping' that does not specify the HTTP method. CSRF protections are not enabled for GET, HEAD, TRACE, or OPTIONS, and by default all HTTP methods are allowed when the HTTP method is not explicitly specified. This means that a method that performs state changes could be vulnerable to CSRF attacks. To mitigate, add the 'method' field and specify the HTTP method (such as 'RequestMethod.POST').